### PR TITLE
Add children to the ParamCommand and TParamCommand blocks

### DIFF
--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -269,6 +269,8 @@ pub struct ParamCommand {
     pub parameter: String,
     /// The parameter direction, if specified.
     pub direction: Option<ParameterDirection>,
+    /// The children of this parameter command
+    pub children: Vec<CommentChild>
 }
 
 impl ParamCommand {
@@ -286,7 +288,9 @@ impl ParamCommand {
         } else {
             None
         };
-        ParamCommand { index: index, parameter: parameter, direction: direction }
+        let paragraph = clang_BlockCommandComment_getParagraph(raw);
+        let children = Comment::from_raw(paragraph).get_children();
+        ParamCommand { index: index, parameter: parameter, direction: direction, children: children }
     }
 }
 
@@ -300,6 +304,8 @@ pub struct TParamCommand {
     pub position: Option<(usize, usize)>,
     /// The template parameter.
     pub parameter: String,
+    /// The children of this type parameter command
+    pub children: Vec<CommentChild>
 }
 
 impl TParamCommand {
@@ -314,6 +320,8 @@ impl TParamCommand {
             None
         };
         let parameter = utility::to_string(clang_TParamCommandComment_getParamName(raw));
-        TParamCommand { position: position, parameter: parameter }
+        let paragraph = clang_BlockCommandComment_getParagraph(raw);
+        let children = Comment::from_raw(paragraph).get_children();
+        TParamCommand { position: position, parameter: parameter, children: children }
     }
 }

--- a/tests/documentation.rs
+++ b/tests/documentation.rs
@@ -67,10 +67,15 @@ pub fn test(clang: &Clang) {
             CommentChild::Text(" ".into()),
         ]));
         assert_eq!(children[5], CommentChild::TParamCommand(TParamCommand {
-            position: Some((1, 0)), parameter: "T".into(),
+            position: Some((1, 0)), parameter: "T".into(), children: vec![
+                CommentChild::Text(" This template parameter doesn't actually do anything.".into()),
+                CommentChild::Text(" ".into()),
+            ]
         }));
         assert_eq!(children[6], CommentChild::ParamCommand(ParamCommand {
-            index: Some(0), parameter: "i".into(), direction: Some(ParameterDirection::In),
+            index: Some(0), parameter: "i".into(), direction: Some(ParameterDirection::In), children: vec![
+                CommentChild::Text(" This parameter alters the behavior of the function in some way.".into()),
+            ]
         }));
         assert_eq!(children[7], CommentChild::Paragraph(vec![
             CommentChild::Text(" ".into()),


### PR DESCRIPTION
These are specialised instances of BlockCommand, which contain a
parameter they refer to plus the associated comment. Just like
BlockCommand has a children field, so should these variants.