### PR TITLE
Add Entity::get_result_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [0.18.0] - UNRELEASED
 
+### Added
+- Added `Entity::get_result_type` method
+
 ### Changed
 - Bumped `clang-sys` version to `0.21.1`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1739,6 +1739,11 @@ impl<'tu> Entity<'tu> {
         }
     }
 
+    /// Returns the result type of this AST entity, if applicable.
+    pub fn get_result_type(&self) -> Option<Type<'tu>> {
+        unsafe { clang_getCursorResultType(self.raw).map(|t| Type::from_raw(t, self.tu)) }
+    }
+
     /// Returns whether this AST entity has any attached attributes.
     #[cfg(feature="gte_clang_3_9")]
     pub fn has_attributes(&self) -> bool {


### PR DESCRIPTION
You can already do `entity.get_type().get_result_type()` but unfortunately they don't return the same value when the entity is the declaration an Objective-C method.
The code of `clang_getCursorResultType` explicitly handles `ObjCMethodDecl` differently:
https://github.com/llvm-mirror/clang/blob/53d982bea4e15405c228fd90afc486c36d71feed/tools/libclang/CXType.cpp#L680-L690

Note that I haven't added any test for `Entity::get_result_type` yet. The best would probably be to add tests for Objective-C, but currently tests only use C++. I should probably add a parameter to `with_entity` (file name or a language enum), but that would require modifying quite a few places so before doing the modification I would like to have confirmation.