### PR TITLE
Use lazy_static 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.19.0] - UNRELEASED
+
+### Changed
+- Bumped `lazy_static` version to `1.0.0`
+
 ## [0.18.0] - 2018-02-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ gte_clang_5_0 = []
 [dependencies]
 
 clang-sys = "0.21.1"
-lazy_static = "0.2.1"
+lazy_static = "1.0"
 libc = "0.2.16"
 
 clippy = { version = "0.0.*", optional = true }


### PR DESCRIPTION
lazy_static 1.0 seems to be exactly the same as 0.2.11 so I don't think there would be any disadvantages in using 1.0 instead.