### PR TITLE
refactor: Remove the use of lazy_static to init atomic vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ gte_clang_6_0 = []
 [dependencies]
 
 clang-sys = "0.23.0"
-lazy_static = "1.0.0"
 libc = "0.2.39"
 
 [[test]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@
 
 #![allow(non_upper_case_globals)]
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate clang_sys;
 extern crate libc;
 
@@ -1192,7 +1189,7 @@ pub enum Visibility {
 
 // Clang _________________________________________
 
-lazy_static! { static ref AVAILABLE: AtomicBool = AtomicBool::new(true); }
+static AVAILABLE: AtomicBool = AtomicBool::new(true);
 
 /// An empty type which prevents the use of this library from multiple threads simultaneously.
 #[derive(Debug)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 extern crate clang;
 extern crate libc;
 
@@ -49,7 +46,7 @@ fn with_file<'c, F: FnOnce(&Path, File)>(clang: &'c Clang, contents: &str, f: F)
     });
 }
 
-lazy_static! { static ref COUNTER: AtomicUsize = AtomicUsize::new(0); }
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 fn with_temporary_directory<F: FnOnce(&Path)>(f: F) {
     let exe = env::current_exe().unwrap().file_name().unwrap().to_string_lossy().into_owned();


### PR DESCRIPTION
Since `AtomicBool::new` and `AtomicUsize::new` are const function. They can be evaluated at compile time. There is no necessary to use `lazy_static` to wrap them.