### PR TITLE
Update to libclang v8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ clang_3_9 = ["clang-sys/clang_3_9", "gte_clang_3_6", "gte_clang_3_7", "gte_clang
 clang_4_0 = ["clang-sys/clang_4_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0"]
 clang_5_0 = ["clang-sys/clang_5_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0"]
 clang_6_0 = ["clang-sys/clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0"]
+clang_7_0 = ["clang-sys/clang_7_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0"]
+clang_8_0 = ["clang-sys/clang_8_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "gte_clang_7_0", "gte_clang_8_0"]
 
 gte_clang_3_6 = []
 gte_clang_3_7 = []
@@ -36,10 +38,12 @@ gte_clang_3_9 = []
 gte_clang_4_0 = []
 gte_clang_5_0 = []
 gte_clang_6_0 = []
+gte_clang_7_0 = []
+gte_clang_8_0 = []
 
 [dependencies]
 
-clang-sys = "0.26.4"
+clang-sys = "0.28.0"
 libc = "0.2.39"
 
 [[test]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2941,6 +2941,24 @@ impl<'tu> Type<'tu> {
         unsafe { clang_Type_getObjCObjectBaseType(self.raw).map(|t| Type::from_raw(t, self.tu)) }
     }
 
+    /// Returns the declarations for all protocal references for this Objective-C type, if applicable.
+    #[cfg(feature="gte_clang_8_0")]
+    pub fn get_objc_protocal_declarations(&self) -> Option<Vec<Entity<'tu>>> {
+        iter_option!(
+            clang_Type_getNumObjCProtocolRefs(self.raw),
+            clang_Type_getObjCProtocolDecl(self.raw)
+        ).map(|i| i.map(|c| Entity::from_raw(c, self.tu)).collect())
+    }
+
+    /// Returns the type arguments for this Objective-C type, if applicable.
+    #[cfg(feature="gte_clang_8_0")]
+    pub fn get_objc_type_arguments(&self) -> Option<Vec<Type<'tu>>> {
+        iter_option!(
+            clang_Type_getNumObjCTypeArgs(self.raw),
+            clang_Type_getObjCTypeArg(self.raw)
+        ).map(|i| i.map(|t| Type::from_raw(t, self.tu)).collect())
+    }
+
     /// Return the type that was modified by this attributed type.
     #[cfg(feature="gte_clang_8_0")]
     pub fn get_modified_type(&self) -> Option<Type<'tu>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1336,6 +1336,11 @@ impl<'tu> Entity<'tu> {
         unsafe { utility::to_string_option(clang_getCursorDisplayName(self.raw)) }
     }
 
+    /// Returns the pretty printer for this declaration.
+    pub fn get_pretty_printer(&self) -> PrettyPrinter {
+        unsafe { PrettyPrinter::from_raw(clang_getCursorPrintingPolicy(self.raw), self) }
+    }
+
     /// Returns the source location of this AST entity, if any.
     pub fn get_location(&self) -> Option<SourceLocation<'tu>> {
         unsafe { clang_getCursorLocation(self.raw).map(|l| SourceLocation::from_raw(l, self.tu)) }
@@ -2342,6 +2347,7 @@ impl PlatformAvailability {
 
 /// Pretty prints declarations.
 #[cfg(feature="gte_clang_7_0")]
+#[derive(Debug)]
 pub struct PrettyPrinter<'e> {
     ptr: CXPrintingPolicy,
     entity: &'e Entity<'e>,
@@ -2359,7 +2365,7 @@ impl<'e> PrettyPrinter<'e> {
 
     /// Pretty print the declaration.
     pub fn print(&self) -> String {
-        unsafe { utility::to_string(clang_getCursorPrettyPrinted(self.entity, self.ptr)) }
+        unsafe { utility::to_string(clang_getCursorPrettyPrinted(self.entity.raw, self.ptr)) }
     }
 
     //- Properties -------------------------------
@@ -2370,43 +2376,44 @@ impl<'e> PrettyPrinter<'e> {
     }
 
     /// Sets the number of spaces used to indent each line.
-    pub fn get_indentation_amount(&self, value: u8) {
+    pub fn set_indentation_amount(&self, value: u8) -> &Self {
         unsafe {
-            clang_PrintingPolicy_setProperty(self.ptr, CXPrintingPolicy_Indentation, value.into())
+            clang_PrintingPolicy_setProperty(self.ptr, CXPrintingPolicy_Indentation, value.into());
         }
+        self
     }
 
     extern_properties!{
         with {
             clang_PrintingPolicy_getProperty,
-            clang_PrintingPolicy_setProperty
+            clang_PrintingPolicy_setProperty,
         }
 
-        CXPrintingPolicy_SuppressSpecifiers: bool {
+        pub CXPrintingPolicy_SuppressSpecifiers: bool {
             /// Gets whether to suppress printing specifiers for a given type or declaration.
             get_suppress_specifiers,
             /// Sets whether to suppress printing specifiers for a given type or declaration.
             set_suppress_specifiers,
         }
-        CXPrintingPolicy_SuppressTagKeyword: bool {
+        pub CXPrintingPolicy_SuppressTagKeyword: bool {
             /// Gets whether to suppress printing the tag keyword.
             get_suppress_tag_keyword,
             /// Sets whether to suppress printing the tag keyword.
             set_suppress_tag_keyword,
         }
-        CXPrintingPolicy_IncludeTagDefinition: bool {
+        pub CXPrintingPolicy_IncludeTagDefinition: bool {
             /// Gets whether to include the body of a tag definition.
             get_include_tag_definition,
             /// Gets whether to include the body of a tag definition.
             set_include_tag_definition,
         }
-        CXPrintingPolicy_SuppressScope: bool {
+        pub CXPrintingPolicy_SuppressScope: bool {
             /// Gets whether to suppress printing of scope speifiers.
             get_suppress_scope,
             /// Sets whether to suppress printing of scope speifiers.
             set_suppress_scope,
         }
-        CXPrintingPolicy_SuppressUnwrittenScope: bool {
+        pub CXPrintingPolicy_SuppressUnwrittenScope: bool {
             /// Gets whether to suppress printing the parts of scope specifiers that don't need to
             /// be written.
             get_suppress_unwritten_scope,
@@ -2414,67 +2421,67 @@ impl<'e> PrettyPrinter<'e> {
             /// be written.
             set_suppress_unwritten_scope,
         }
-        CXPrintingPolicy_SuppressInitializers: bool {
+        pub CXPrintingPolicy_SuppressInitializers: bool {
             /// Gets whether to suppress printing of variable initializers.
             get_suppress_initializers,
             /// Sets whether to suppress printing of variable initializers.
             set_suppress_initializers,
         }
-        CXPrintingPolicy_ConstantArraySizeAsWritten: bool {
+        pub CXPrintingPolicy_ConstantArraySizeAsWritten: bool {
             /// Gets whether to print the size of constant array expressions as written.
             get_print_constant_array_size_as_written,
             /// Sets whether to print the size of constant array expressions as written.
             set_print_constant_array_size_as_written,
         }
-        CXPrintingPolicy_AnonymousTagLocations: bool {
+        pub CXPrintingPolicy_AnonymousTagLocations: bool {
             /// Gets whether to print the location of anonymous tags.
             get_print_anonymous_tag_locations,
             /// Sets whether to print the location of anonymous tags.
             set_print_anonymous_tag_locations,
         }
-        CXPrintingPolicy_SuppressStrongLifetime: bool {
+        pub CXPrintingPolicy_SuppressStrongLifetime: bool {
             /// Gets whether to suppress printing the __strong lifetime qualifier in ARC.
             get_suppress_strong_lifetime,
             /// Sets whether to suppress printing the __strong lifetime qualifier in ARC.
             set_suppress_strong_lifetime,
         }
-        CXPrintingPolicy_SuppressLifetimeQualifiers: bool {
+        pub CXPrintingPolicy_SuppressLifetimeQualifiers: bool {
             /// Gets whether to suppress printing lifetime qualifiers in ARC.
             get_suppress_lifetime_qualifiers,
             /// Sets whether to suppress printing lifetime qualifiers in ARC.
             set_suppress_lifetime_qualifiers,
         }
-        CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors: bool {
+        pub CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors: bool {
             /// Gets whether to suppress printing template arguments in names of C++ constructors.
             get_suppress_template_args_in_cxx_constructors,
             /// Sets whether to suppress printing template arguments in names of C++ constructors.
             set_suppress_template_args_in_cxx_constructors,
         }
-        CXPrintingPolicy_Bool: bool {
+        pub CXPrintingPolicy_Bool: bool {
             /// Gets whether to print 'bool' rather than '_Bool'.
             get_use_bool,
             /// Sets whether to print 'bool' rather than '_Bool'.
             set_use_bool,
         }
-        CXPrintingPolicy_: bool {
+        pub CXPrintingPolicy_Restrict: bool {
             /// Gets whether to print 'restrict' rather than '__restrict'
             get_use_restrict,
             /// Sets whether to print 'restrict' rather than '__restrict'
             set_use_restrict,
         }
-        CXPrintingPolicy_: bool {
+        pub CXPrintingPolicy_Alignof: bool {
             /// Gets whether to print 'alignof' rather than '__alignof'
             get_use_alignof,
             /// Sets whether to print 'alignof' rather than '__alignof'
             set_use_alignof,
         }
-        CXPrintingPolicy_UnderscoreAlignof: bool {
+        pub CXPrintingPolicy_UnderscoreAlignof: bool {
             /// Gets whether to print '_Alignof' rather than '__alignof'
             get_use_underscore_alignof,
             /// Sets whether to print '_Alignof' rather than '__alignof'
             set_use_underscore_alignof,
         }
-        CXPrintingPolicy_UseVoidForZeroParams: bool {
+        pub CXPrintingPolicy_UseVoidForZeroParams: bool {
             /// Gets whether to print '(void)' rather then '()' for a function prototype with zero
             /// parameters.
             get_use_void_for_zero_params,
@@ -2482,13 +2489,13 @@ impl<'e> PrettyPrinter<'e> {
             /// parameters.
             set_use_void_for_zero_params,
         }
-        CXPrintingPolicy_TerseOutput: bool {
+        pub CXPrintingPolicy_TerseOutput: bool {
             /// Gets whether to print terse output.
             get_use_terse_output,
             /// Sets whether to print terse output.
             set_use_terse_output,
         }
-        CXPrintingPolicy_PolishForDeclaration: bool {
+        pub CXPrintingPolicy_PolishForDeclaration: bool {
             /// Gets whether to do certain refinements needed for producing a proper declaration
             /// tag.
             get_polish_for_declaration,
@@ -2496,43 +2503,43 @@ impl<'e> PrettyPrinter<'e> {
             /// tag.
             set_polish_for_declaration,
         }
-        CXPrintingPolicy_Half: bool {
+        pub CXPrintingPolicy_Half: bool {
             /// Gets whether to print 'half' rather than '__fp16'
             get_use_half,
             /// Sets whether to print 'half' rather than '__fp16'
             set_use_half,
         }
-        CXPrintingPolicy_MSWChar: bool {
+        pub CXPrintingPolicy_MSWChar: bool {
             /// Gets whether to print the built-in wchar_t type as '__wchar_t'
             get_use_ms_wchar,
             /// Sets whether to print the built-in wchar_t type as '__wchar_t'
             set_use_ms_wchar,
         }
-        CXPrintingPolicy_IncludeNewlines: bool {
+        pub CXPrintingPolicy_IncludeNewlines: bool {
             /// Gets whether to include newlines after statements.
             get_include_newlines,
             /// Sets whether to include newlines after statements.
             set_include_newlines,
         }
-        CXPrintingPolicy_MSVCFormatting: bool {
+        pub CXPrintingPolicy_MSVCFormatting: bool {
             /// Gets whether to use whitespace and punctuation like MSVC does.
             get_msvc_formatting,
             /// Sets whether to use whitespace and punctuation like MSVC does.
             set_msvc_formatting,
         }
-        CXPrintingPolicy_ConstantsAsWritten: bool {
+        pub CXPrintingPolicy_ConstantsAsWritten: bool {
             /// Gets whether to print constant expressions as written.
             get_print_constants_as_written,
             /// Sets whether to print constant expressions as written.
             set_print_constants_as_written,
         }
-        CXPrintingPolicy_SuppressImplicitBase: bool {
+        pub CXPrintingPolicy_SuppressImplicitBase: bool {
             /// Gets whether to suppress printing the implicit 'self' or 'this' expressions.
             get_suppress_implicit_base,
             /// Sets whether to suppress printing the implicit 'self' or 'this' expressions.
             set_suppress_implicit_base,
         }
-        CXPrintingPolicy_FullyQualifiedName: bool {
+        pub CXPrintingPolicy_FullyQualifiedName: bool {
             /// Gets whether to print the fully qualified name of function declarations.
             get_print_fully_qualified_name,
             /// Sets whether to print the fully qualified name of function declarations.
@@ -2937,26 +2944,26 @@ impl<'tu> Type<'tu> {
 
     /// Returns the base type of this Objective-C type, if applicable.
     #[cfg(feature="gte_clang_8_0")]
-    pub fn get_objc_object_base_type(&self) -> Option<String> {
+    pub fn get_objc_object_base_type(&self) -> Option<Type> {
         unsafe { clang_Type_getObjCObjectBaseType(self.raw).map(|t| Type::from_raw(t, self.tu)) }
     }
 
     /// Returns the declarations for all protocal references for this Objective-C type, if applicable.
     #[cfg(feature="gte_clang_8_0")]
-    pub fn get_objc_protocal_declarations(&self) -> Option<Vec<Entity<'tu>>> {
-        iter_option!(
+    pub fn get_objc_protocal_declarations(&self) -> Vec<Entity<'tu>> {
+        iter!(
             clang_Type_getNumObjCProtocolRefs(self.raw),
-            clang_Type_getObjCProtocolDecl(self.raw)
-        ).map(|i| i.map(|c| Entity::from_raw(c, self.tu)).collect())
+            clang_Type_getObjCProtocolDecl(self.raw),
+        ).map(|c| Entity::from_raw(c, self.tu)).collect()
     }
 
     /// Returns the type arguments for this Objective-C type, if applicable.
     #[cfg(feature="gte_clang_8_0")]
-    pub fn get_objc_type_arguments(&self) -> Option<Vec<Type<'tu>>> {
-        iter_option!(
+    pub fn get_objc_type_arguments(&self) -> Vec<Type<'tu>> {
+        iter!(
             clang_Type_getNumObjCTypeArgs(self.raw),
-            clang_Type_getObjCTypeArg(self.raw)
-        ).map(|i| i.map(|t| Type::from_raw(t, self.tu)).collect())
+            clang_Type_getObjCTypeArg(self.raw),
+        ).map(|t| Type::from_raw(t, self.tu)).collect()
     }
 
     /// Return the type that was modified by this attributed type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1793,7 +1793,7 @@ impl<'tu> Entity<'tu> {
 
     /// Returns the the offset of this field, if applicable.
     #[cfg(feature="gte_clang_3_7")]
-    pub fn get_offset_of_field<F: AsRef<str>>(&self) -> Result<usize, OffsetofError> {
+    pub fn get_offset_of_field(&self) -> Result<usize, OffsetofError> {
         let offsetof_ = unsafe { clang_Cursor_getOffsetOfField(self.raw) };
         OffsetofError::from_error(offsetof_).map(|_| offsetof_ as usize)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2338,6 +2338,216 @@ impl PlatformAvailability {
     }
 }
 
+// PrettyPrinter _________________________________
+
+/// Pretty prints declarations.
+#[cfg(feature="gte_clang_7_0")]
+pub struct PrettyPrinter<'e> {
+    ptr: CXPrintingPolicy,
+    entity: &'e Entity<'e>,
+}
+#[cfg(feature="gte_clang_7_0")]
+impl<'e> PrettyPrinter<'e> {
+    //- Constructors -----------------------------
+
+    fn from_raw(ptr: CXPrintingPolicy, entity: &'e Entity<'e>) -> Self {
+        assert!(ptr.is_null());
+        PrettyPrinter { ptr, entity }
+    }
+
+    //- Accessors --------------------------------
+
+    /// Pretty print the declaration.
+    pub fn print(&self) -> String {
+        unsafe { utility::to_string(clang_getCursorPrettyPrinted(self.entity, self.ptr)) }
+    }
+
+    //- Properties -------------------------------
+
+    /// Gets the number of spaces used to indent each line.
+    pub fn get_indentation_amount(&self) -> u8 {
+        unsafe { clang_PrintingPolicy_getProperty(self.ptr, CXPrintingPolicy_Indentation) as u8 }
+    }
+
+    /// Sets the number of spaces used to indent each line.
+    pub fn get_indentation_amount(&self, value: u8) {
+        unsafe {
+            clang_PrintingPolicy_setProperty(self.ptr, CXPrintingPolicy_Indentation, value.into())
+        }
+    }
+
+    extern_properties!{
+        with {
+            clang_PrintingPolicy_getProperty,
+            clang_PrintingPolicy_setProperty
+        }
+
+        CXPrintingPolicy_SuppressSpecifiers: bool {
+            /// Gets whether to suppress printing specifiers for a given type or declaration.
+            get_suppress_specifiers,
+            /// Sets whether to suppress printing specifiers for a given type or declaration.
+            set_suppress_specifiers,
+        }
+        CXPrintingPolicy_SuppressTagKeyword: bool {
+            /// Gets whether to suppress printing the tag keyword.
+            get_suppress_tag_keyword,
+            /// Sets whether to suppress printing the tag keyword.
+            set_suppress_tag_keyword,
+        }
+        CXPrintingPolicy_IncludeTagDefinition: bool {
+            /// Gets whether to include the body of a tag definition.
+            get_include_tag_definition,
+            /// Gets whether to include the body of a tag definition.
+            set_include_tag_definition,
+        }
+        CXPrintingPolicy_SuppressScope: bool {
+            /// Gets whether to suppress printing of scope speifiers.
+            get_suppress_scope,
+            /// Sets whether to suppress printing of scope speifiers.
+            set_suppress_scope,
+        }
+        CXPrintingPolicy_SuppressUnwrittenScope: bool {
+            /// Gets whether to suppress printing the parts of scope specifiers that don't need to
+            /// be written.
+            get_suppress_unwritten_scope,
+            /// Sets whether to suppress printing the parts of scope specifiers that don't need to
+            /// be written.
+            set_suppress_unwritten_scope,
+        }
+        CXPrintingPolicy_SuppressInitializers: bool {
+            /// Gets whether to suppress printing of variable initializers.
+            get_suppress_initializers,
+            /// Sets whether to suppress printing of variable initializers.
+            set_suppress_initializers,
+        }
+        CXPrintingPolicy_ConstantArraySizeAsWritten: bool {
+            /// Gets whether to print the size of constant array expressions as written.
+            get_print_constant_array_size_as_written,
+            /// Sets whether to print the size of constant array expressions as written.
+            set_print_constant_array_size_as_written,
+        }
+        CXPrintingPolicy_AnonymousTagLocations: bool {
+            /// Gets whether to print the location of anonymous tags.
+            get_print_anonymous_tag_locations,
+            /// Sets whether to print the location of anonymous tags.
+            set_print_anonymous_tag_locations,
+        }
+        CXPrintingPolicy_SuppressStrongLifetime: bool {
+            /// Gets whether to suppress printing the __strong lifetime qualifier in ARC.
+            get_suppress_strong_lifetime,
+            /// Sets whether to suppress printing the __strong lifetime qualifier in ARC.
+            set_suppress_strong_lifetime,
+        }
+        CXPrintingPolicy_SuppressLifetimeQualifiers: bool {
+            /// Gets whether to suppress printing lifetime qualifiers in ARC.
+            get_suppress_lifetime_qualifiers,
+            /// Sets whether to suppress printing lifetime qualifiers in ARC.
+            set_suppress_lifetime_qualifiers,
+        }
+        CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors: bool {
+            /// Gets whether to suppress printing template arguments in names of C++ constructors.
+            get_suppress_template_args_in_cxx_constructors,
+            /// Sets whether to suppress printing template arguments in names of C++ constructors.
+            set_suppress_template_args_in_cxx_constructors,
+        }
+        CXPrintingPolicy_Bool: bool {
+            /// Gets whether to print 'bool' rather than '_Bool'.
+            get_use_bool,
+            /// Sets whether to print 'bool' rather than '_Bool'.
+            set_use_bool,
+        }
+        CXPrintingPolicy_: bool {
+            /// Gets whether to print 'restrict' rather than '__restrict'
+            get_use_restrict,
+            /// Sets whether to print 'restrict' rather than '__restrict'
+            set_use_restrict,
+        }
+        CXPrintingPolicy_: bool {
+            /// Gets whether to print 'alignof' rather than '__alignof'
+            get_use_alignof,
+            /// Sets whether to print 'alignof' rather than '__alignof'
+            set_use_alignof,
+        }
+        CXPrintingPolicy_UnderscoreAlignof: bool {
+            /// Gets whether to print '_Alignof' rather than '__alignof'
+            get_use_underscore_alignof,
+            /// Sets whether to print '_Alignof' rather than '__alignof'
+            set_use_underscore_alignof,
+        }
+        CXPrintingPolicy_UseVoidForZeroParams: bool {
+            /// Gets whether to print '(void)' rather then '()' for a function prototype with zero
+            /// parameters.
+            get_use_void_for_zero_params,
+            /// Sets whether to print '(void)' rather then '()' for a function prototype with zero
+            /// parameters.
+            set_use_void_for_zero_params,
+        }
+        CXPrintingPolicy_TerseOutput: bool {
+            /// Gets whether to print terse output.
+            get_use_terse_output,
+            /// Sets whether to print terse output.
+            set_use_terse_output,
+        }
+        CXPrintingPolicy_PolishForDeclaration: bool {
+            /// Gets whether to do certain refinements needed for producing a proper declaration
+            /// tag.
+            get_polish_for_declaration,
+            /// Sets whether to do certain refinements needed for producing a proper declaration
+            /// tag.
+            set_polish_for_declaration,
+        }
+        CXPrintingPolicy_Half: bool {
+            /// Gets whether to print 'half' rather than '__fp16'
+            get_use_half,
+            /// Sets whether to print 'half' rather than '__fp16'
+            set_use_half,
+        }
+        CXPrintingPolicy_MSWChar: bool {
+            /// Gets whether to print the built-in wchar_t type as '__wchar_t'
+            get_use_ms_wchar,
+            /// Sets whether to print the built-in wchar_t type as '__wchar_t'
+            set_use_ms_wchar,
+        }
+        CXPrintingPolicy_IncludeNewlines: bool {
+            /// Gets whether to include newlines after statements.
+            get_include_newlines,
+            /// Sets whether to include newlines after statements.
+            set_include_newlines,
+        }
+        CXPrintingPolicy_MSVCFormatting: bool {
+            /// Gets whether to use whitespace and punctuation like MSVC does.
+            get_msvc_formatting,
+            /// Sets whether to use whitespace and punctuation like MSVC does.
+            set_msvc_formatting,
+        }
+        CXPrintingPolicy_ConstantsAsWritten: bool {
+            /// Gets whether to print constant expressions as written.
+            get_print_constants_as_written,
+            /// Sets whether to print constant expressions as written.
+            set_print_constants_as_written,
+        }
+        CXPrintingPolicy_SuppressImplicitBase: bool {
+            /// Gets whether to suppress printing the implicit 'self' or 'this' expressions.
+            get_suppress_implicit_base,
+            /// Sets whether to suppress printing the implicit 'self' or 'this' expressions.
+            set_suppress_implicit_base,
+        }
+        CXPrintingPolicy_FullyQualifiedName: bool {
+            /// Gets whether to print the fully qualified name of function declarations.
+            get_print_fully_qualified_name,
+            /// Sets whether to print the fully qualified name of function declarations.
+            set_print_fully_qualified_name,
+        }
+    }
+}
+
+#[cfg(feature="gte_clang_7_0")]
+impl<'e> Drop for PrettyPrinter<'e> {
+    fn drop(&mut self) {
+        unsafe { clang_PrintingPolicy_dispose(self.ptr) }
+    }
+}
+
 // Target ________________________________________
 
 /// Information about the target for a translation unit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1336,6 +1336,7 @@ impl<'tu> Entity<'tu> {
         unsafe { utility::to_string_option(clang_getCursorDisplayName(self.raw)) }
     }
 
+    #[cfg(feature="gte_clang_7_0")]
     /// Returns the pretty printer for this declaration.
     pub fn get_pretty_printer(&self) -> PrettyPrinter {
         unsafe { PrettyPrinter::from_raw(clang_getCursorPrintingPolicy(self.raw), self) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,10 @@ pub enum EntityKind {
     ///
     /// Only produced by `libclang` 3.9 and later.
     ObjCAvailabilityCheckExpr = 148,
+    /// A fixed-point literal.
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    FixedPointLiteral = 149,
     /// A statement whose specific kind is not exposed via this interface.
     UnexposedStmt = 200,
     /// A labelled statement in a function.
@@ -640,6 +644,78 @@ pub enum EntityKind {
     ///
     /// Only produced by `libclang` 3.8 and later.
     DllImport = 419,
+    /// `__attribute__((ns_returns_retained))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    NSReturnsRetained = 420,
+    /// `__attribute__((ns_returns_not_retained))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    NSReturnsNotRetained = 421,
+    /// `__attribute__((ns_returns_autoreleased))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    NSReturnsAutoreleased = 422,
+    /// `__attribute__((ns_consumes_self))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    NSConsumesSelf = 423,
+    /// `__attribute__((ns_consumed))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    NSConsumed = 424,
+    /// `__attribute__((objc_exception))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCException = 425,
+    /// `__attribute__((NSObject))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCNSObject = 426,
+    /// `__attribute__((objc_independent_class))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCIndependentClass = 427,
+    /// `__attribute__((objc_precise_lifetime))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCPreciseLifetime = 428,
+    /// `__attribute__((objc_returns_inner_pointer))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCReturnsInnerPointer = 429,
+    /// `__attribute__((objc_requires_super))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCRequiresSuper = 430,
+    /// `__attribute__((objc_root_class))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCRootClass = 431,
+    /// `__attribute__((objc_subclassing_restricted))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCSubclassingRestricted = 432,
+    /// `__attribute__((objc_protocol_requires_explicit_implementation))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCExplicitProtocolImpl = 433,
+    /// `__attribute__((objc_designated_initializer))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCDesignatedInitializer = 434,
+    /// `__attribute__((objc_runtime_visible))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCRuntimeVisible = 435,
+    /// `__attribute__((objc_boxable))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCBoxable = 436,
+    /// `__attribute__((flag_enum))`
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    FlagEnum = 437,
     /// A preprocessing directive.
     PreprocessingDirective = 500,
     /// A macro definition.
@@ -951,6 +1027,30 @@ pub enum TypeKind {
     ///
     /// Only produced by `libclang` 6.0 and later.
     Float16 = 32,
+    /// `short _Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    ShortAccum = 33,
+    /// `_Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    Accum = 34,
+    /// `long _Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    LongAccum = 35,
+    /// `unsigned short _Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    UShortAccum = 36,
+    /// `unsigned _Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    UAccum = 37,
+    /// `unsigned long _Accum`
+    ///
+    /// Only produced by `libclang` 7.0 and later.
+    ULongAccum = 38,
     /// `float`
     Float = 21,
     /// `double`
@@ -1181,6 +1281,66 @@ pub enum TypeKind {
     ///
     /// Only produced by `libclang` 5.0 and later.
     OCLReserveID = 160,
+    /// An Objective-C object type.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCObject = 161,
+    /// An Objective-C type param.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    ObjCTypeParam = 162,
+    /// An attributed type.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    Attributed = 163,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCMcePayload = 164,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImePayload = 165,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCRefPayload = 166,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCSicPayload = 167,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCMceResult = 168,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImeResult = 169,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCRefResult = 170,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCSicResult = 171,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImeResultSingleRefStreamout = 172,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImeResultDualRefStreamout = 173,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
+    /// An Intel OpenCL extension type for the AVC VME media sampler in Intel graphics processors.
+    ///
+    /// Only produced by `libclang` 8.0 and later.
+    OCLIntelSubgroupAVCImeDualRefStreamin = 175,
 }
 
 // Visibility ____________________________________

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,6 +895,65 @@ pub enum Nullability {
     Unspecified = 2,
 }
 
+// PrintingPolicyFlag ____________________________
+
+/// Flags for the printing policy.
+#[cfg(feature="gte_clang_7_0")]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub enum PrintingPolicyFlag {
+    /// Whether to suppress printing specifiers for a given type or declaration.
+    SuppressSpecifiers = 1,
+    /// Whether to suppress printing the tag keyword.
+    SuppressTagKeyword = 2,
+    /// Whether to include the body of a tag definition.
+    IncludeTagDefinition = 3,
+    /// Whether to suppress printing of scope specifiers.
+    SuppressScope = 4,
+    /// Whether to suppress printing the parts of scope specifiers that don't need to be written.
+    SuppressUnwrittenScope = 5,
+    /// Whether to suppress printing of variable initializers.
+    SuppressInitializers = 6,
+    /// Whether to print the size of constant array expressions as written.
+    PrintConstantArraySizeAsWritten = 7,
+    /// Whether to print the location of anonymous tags.
+    PrintAnonymousTagLocations = 8,
+    /// Whether to suppress printing the __strong lifetime qualifier in ARC.
+    SuppressStrongLifetime = 9,
+    /// Whether to suppress printing lifetime qualifiers in ARC.
+    SuppressLifetimeQualifiers = 10,
+    /// Whether to suppress printing template arguments in names of C++ constructors.
+    SuppressTemplateArgsInCXXConstructors = 11,
+    /// Whether to print 'bool' rather than '_Bool'.
+    UseBool = 12,
+    /// Whether to print 'restrict' rather than '__restrict'
+    UseRestrict = 13,
+    /// Whether to print 'alignof' rather than '__alignof'
+    UseAlignof = 14,
+    /// Whether to print '_Alignof' rather than '__alignof'
+    UseUnderscoreAlignof = 15,
+    /// Whether to print '(void)' rather then '()' for a function prototype with zero parameters.
+    UseVoidForZeroParams = 16,
+    /// Whether to print terse output.
+    UseTerseOutput = 17,
+    /// Whether to do certain refinements needed for producing a proper declaration tag.
+    PolishForDeclaration = 18,
+    /// Whether to print 'half' rather than '__fp16'
+    UseHalf = 19,
+    /// Whether to print the built-in wchar_t type as '__wchar_t'
+    UseMsWchar = 20,
+    /// Whether to include newlines after statements.
+    IncludeNewlines = 21,
+    /// Whether to use whitespace and punctuation like MSVC does.
+    UseMsvcFormatting = 22,
+    /// Whether to print constant expressions as written.
+    PrintConstantsAsWritten = 23,
+    /// Whether to suppress printing the implicit 'self' or 'this' expressions.
+    SuppressImplicitBase = 24,
+    /// Whether to print the fully qualified name of function declarations.
+    PrintFullyQualifiedName = 25,
+}
+
 // RefQualifier __________________________________
 
 /// Indicates the ref qualifier of a C++ function or method type.
@@ -2524,12 +2583,17 @@ impl<'e> PrettyPrinter<'e> {
 
     //- Accessors --------------------------------
 
-    /// Pretty print the declaration.
-    pub fn print(&self) -> String {
-        unsafe { utility::to_string(clang_getCursorPrettyPrinted(self.entity.raw, self.ptr)) }
+    /// Gets the specified flag value.
+    pub fn get_flag(&self, flag: PrintingPolicyFlag) -> bool {
+        unsafe { clang_PrintingPolicy_getProperty(self.ptr, mem::transmute(flag)) != 0 }
     }
 
-    //- Properties -------------------------------
+    /// Sets the specified flag value.
+    pub fn set_flag(&self, flag: PrintingPolicyFlag, value: bool) -> &Self {
+        let value = if value { 1 } else { 0 };
+        unsafe { clang_PrintingPolicy_setProperty(self.ptr, mem::transmute(flag), value); }
+        self
+    }
 
     /// Gets the number of spaces used to indent each line.
     pub fn get_indentation_amount(&self) -> u8 {
@@ -2544,168 +2608,9 @@ impl<'e> PrettyPrinter<'e> {
         self
     }
 
-    extern_properties!{
-        with {
-            clang_PrintingPolicy_getProperty,
-            clang_PrintingPolicy_setProperty,
-        }
-
-        pub CXPrintingPolicy_SuppressSpecifiers: bool {
-            /// Gets whether to suppress printing specifiers for a given type or declaration.
-            get_suppress_specifiers,
-            /// Sets whether to suppress printing specifiers for a given type or declaration.
-            set_suppress_specifiers,
-        }
-        pub CXPrintingPolicy_SuppressTagKeyword: bool {
-            /// Gets whether to suppress printing the tag keyword.
-            get_suppress_tag_keyword,
-            /// Sets whether to suppress printing the tag keyword.
-            set_suppress_tag_keyword,
-        }
-        pub CXPrintingPolicy_IncludeTagDefinition: bool {
-            /// Gets whether to include the body of a tag definition.
-            get_include_tag_definition,
-            /// Gets whether to include the body of a tag definition.
-            set_include_tag_definition,
-        }
-        pub CXPrintingPolicy_SuppressScope: bool {
-            /// Gets whether to suppress printing of scope speifiers.
-            get_suppress_scope,
-            /// Sets whether to suppress printing of scope speifiers.
-            set_suppress_scope,
-        }
-        pub CXPrintingPolicy_SuppressUnwrittenScope: bool {
-            /// Gets whether to suppress printing the parts of scope specifiers that don't need to
-            /// be written.
-            get_suppress_unwritten_scope,
-            /// Sets whether to suppress printing the parts of scope specifiers that don't need to
-            /// be written.
-            set_suppress_unwritten_scope,
-        }
-        pub CXPrintingPolicy_SuppressInitializers: bool {
-            /// Gets whether to suppress printing of variable initializers.
-            get_suppress_initializers,
-            /// Sets whether to suppress printing of variable initializers.
-            set_suppress_initializers,
-        }
-        pub CXPrintingPolicy_ConstantArraySizeAsWritten: bool {
-            /// Gets whether to print the size of constant array expressions as written.
-            get_print_constant_array_size_as_written,
-            /// Sets whether to print the size of constant array expressions as written.
-            set_print_constant_array_size_as_written,
-        }
-        pub CXPrintingPolicy_AnonymousTagLocations: bool {
-            /// Gets whether to print the location of anonymous tags.
-            get_print_anonymous_tag_locations,
-            /// Sets whether to print the location of anonymous tags.
-            set_print_anonymous_tag_locations,
-        }
-        pub CXPrintingPolicy_SuppressStrongLifetime: bool {
-            /// Gets whether to suppress printing the __strong lifetime qualifier in ARC.
-            get_suppress_strong_lifetime,
-            /// Sets whether to suppress printing the __strong lifetime qualifier in ARC.
-            set_suppress_strong_lifetime,
-        }
-        pub CXPrintingPolicy_SuppressLifetimeQualifiers: bool {
-            /// Gets whether to suppress printing lifetime qualifiers in ARC.
-            get_suppress_lifetime_qualifiers,
-            /// Sets whether to suppress printing lifetime qualifiers in ARC.
-            set_suppress_lifetime_qualifiers,
-        }
-        pub CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors: bool {
-            /// Gets whether to suppress printing template arguments in names of C++ constructors.
-            get_suppress_template_args_in_cxx_constructors,
-            /// Sets whether to suppress printing template arguments in names of C++ constructors.
-            set_suppress_template_args_in_cxx_constructors,
-        }
-        pub CXPrintingPolicy_Bool: bool {
-            /// Gets whether to print 'bool' rather than '_Bool'.
-            get_use_bool,
-            /// Sets whether to print 'bool' rather than '_Bool'.
-            set_use_bool,
-        }
-        pub CXPrintingPolicy_Restrict: bool {
-            /// Gets whether to print 'restrict' rather than '__restrict'
-            get_use_restrict,
-            /// Sets whether to print 'restrict' rather than '__restrict'
-            set_use_restrict,
-        }
-        pub CXPrintingPolicy_Alignof: bool {
-            /// Gets whether to print 'alignof' rather than '__alignof'
-            get_use_alignof,
-            /// Sets whether to print 'alignof' rather than '__alignof'
-            set_use_alignof,
-        }
-        pub CXPrintingPolicy_UnderscoreAlignof: bool {
-            /// Gets whether to print '_Alignof' rather than '__alignof'
-            get_use_underscore_alignof,
-            /// Sets whether to print '_Alignof' rather than '__alignof'
-            set_use_underscore_alignof,
-        }
-        pub CXPrintingPolicy_UseVoidForZeroParams: bool {
-            /// Gets whether to print '(void)' rather then '()' for a function prototype with zero
-            /// parameters.
-            get_use_void_for_zero_params,
-            /// Sets whether to print '(void)' rather then '()' for a function prototype with zero
-            /// parameters.
-            set_use_void_for_zero_params,
-        }
-        pub CXPrintingPolicy_TerseOutput: bool {
-            /// Gets whether to print terse output.
-            get_use_terse_output,
-            /// Sets whether to print terse output.
-            set_use_terse_output,
-        }
-        pub CXPrintingPolicy_PolishForDeclaration: bool {
-            /// Gets whether to do certain refinements needed for producing a proper declaration
-            /// tag.
-            get_polish_for_declaration,
-            /// Sets whether to do certain refinements needed for producing a proper declaration
-            /// tag.
-            set_polish_for_declaration,
-        }
-        pub CXPrintingPolicy_Half: bool {
-            /// Gets whether to print 'half' rather than '__fp16'
-            get_use_half,
-            /// Sets whether to print 'half' rather than '__fp16'
-            set_use_half,
-        }
-        pub CXPrintingPolicy_MSWChar: bool {
-            /// Gets whether to print the built-in wchar_t type as '__wchar_t'
-            get_use_ms_wchar,
-            /// Sets whether to print the built-in wchar_t type as '__wchar_t'
-            set_use_ms_wchar,
-        }
-        pub CXPrintingPolicy_IncludeNewlines: bool {
-            /// Gets whether to include newlines after statements.
-            get_include_newlines,
-            /// Sets whether to include newlines after statements.
-            set_include_newlines,
-        }
-        pub CXPrintingPolicy_MSVCFormatting: bool {
-            /// Gets whether to use whitespace and punctuation like MSVC does.
-            get_msvc_formatting,
-            /// Sets whether to use whitespace and punctuation like MSVC does.
-            set_msvc_formatting,
-        }
-        pub CXPrintingPolicy_ConstantsAsWritten: bool {
-            /// Gets whether to print constant expressions as written.
-            get_print_constants_as_written,
-            /// Sets whether to print constant expressions as written.
-            set_print_constants_as_written,
-        }
-        pub CXPrintingPolicy_SuppressImplicitBase: bool {
-            /// Gets whether to suppress printing the implicit 'self' or 'this' expressions.
-            get_suppress_implicit_base,
-            /// Sets whether to suppress printing the implicit 'self' or 'this' expressions.
-            set_suppress_implicit_base,
-        }
-        pub CXPrintingPolicy_FullyQualifiedName: bool {
-            /// Gets whether to print the fully qualified name of function declarations.
-            get_print_fully_qualified_name,
-            /// Sets whether to print the fully qualified name of function declarations.
-            set_print_fully_qualified_name,
-        }
+    /// Pretty print the declaration.
+    pub fn print(&self) -> String {
+        unsafe { utility::to_string(clang_getCursorPrettyPrinted(self.entity.raw, self.ptr)) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2358,7 +2358,7 @@ impl<'e> PrettyPrinter<'e> {
     //- Constructors -----------------------------
 
     fn from_raw(ptr: CXPrintingPolicy, entity: &'e Entity<'e>) -> Self {
-        assert!(ptr.is_null());
+        assert!(!ptr.is_null());
         PrettyPrinter { ptr, entity }
     }
 
@@ -2949,9 +2949,9 @@ impl<'tu> Type<'tu> {
         unsafe { clang_Type_getObjCObjectBaseType(self.raw).map(|t| Type::from_raw(t, self.tu)) }
     }
 
-    /// Returns the declarations for all protocal references for this Objective-C type, if applicable.
+    /// Returns the declarations for all protocol references for this Objective-C type, if applicable.
     #[cfg(feature="gte_clang_8_0")]
-    pub fn get_objc_protocal_declarations(&self) -> Vec<Entity<'tu>> {
+    pub fn get_objc_protocol_declarations(&self) -> Vec<Entity<'tu>> {
         iter!(
             clang_Type_getNumObjCProtocolRefs(self.raw),
             clang_Type_getObjCProtocolDecl(self.raw),

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -52,6 +52,9 @@ macro_rules! builder {
     );
 }
 
+// extern_properties! ____________________________
+
+/// Defines accessors for properties accessed through functions with an enum selector.
 #[cfg(feature="gte_clang_7_0")]
 macro_rules! extern_properties {
     (
@@ -69,12 +72,13 @@ macro_rules! extern_properties {
     ) => ($(
         $(#[$get_doc])+
         pub fn $get_name(&self) -> bool {
-            unsafe { $get_fn(self.ptr) != 0 }
+            unsafe { $get_fn(self.ptr, ::clang_sys::$flag) != 0 }
         }
 
         $(#[$set_doc])+
-        pub fn $set_name(&self, value: bool) {
-            unsafe { $set_fn(self.ptr, if value { 1 } else { 0 }) }
+        pub fn $set_name(&self, value: bool) -> &Self {
+            unsafe { $set_fn(self.ptr, ::clang_sys::$flag, if value { 1 } else { 0 }); }
+            self
         }
     )+);
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -52,6 +52,33 @@ macro_rules! builder {
     );
 }
 
+#[cfg(feature="gte_clang_7_0")]
+macro_rules! extern_properties {
+    (
+        with {
+            $get_fn:ident,
+            $set_fn:ident,
+        }
+
+        $(pub $flag:ident: bool {
+            $(#[$get_doc:meta])+
+            $get_name:ident,
+            $(#[$set_doc:meta])+
+            $set_name:ident,
+        })+
+    ) => ($(
+        $(#[$get_doc])+
+        pub fn $get_name(&self) -> bool {
+            unsafe { $get_fn(self.ptr) != 0 }
+        }
+
+        $(#[$set_doc])+
+        pub fn $set_name(&self, value: bool) {
+            unsafe { $set_fn(self.ptr, if value { 1 } else { 0 }) }
+        }
+    )+);
+}
+
 // iter! _________________________________________
 
 /// Returns an iterator over the values returned by `get_argument`.

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -52,37 +52,6 @@ macro_rules! builder {
     );
 }
 
-// extern_properties! ____________________________
-
-/// Defines accessors for properties accessed through functions with an enum selector.
-#[cfg(feature="gte_clang_7_0")]
-macro_rules! extern_properties {
-    (
-        with {
-            $get_fn:ident,
-            $set_fn:ident,
-        }
-
-        $(pub $flag:ident: bool {
-            $(#[$get_doc:meta])+
-            $get_name:ident,
-            $(#[$set_doc:meta])+
-            $set_name:ident,
-        })+
-    ) => ($(
-        $(#[$get_doc])+
-        pub fn $get_name(&self) -> bool {
-            unsafe { $get_fn(self.ptr, ::clang_sys::$flag) != 0 }
-        }
-
-        $(#[$set_doc])+
-        pub fn $set_name(&self, value: bool) -> &Self {
-            unsafe { $set_fn(self.ptr, ::clang_sys::$flag, if value { 1 } else { 0 }); }
-            self
-        }
-    )+);
-}
-
 // iter! _________________________________________
 
 /// Returns an iterator over the values returned by `get_argument`.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -858,6 +858,67 @@ fn test() {
         test_get_mangled_objc_names(&entities[1]);
     });
 
+    let source = "
+        struct x {
+            char y;
+            char z;
+        }
+    ";
+
+    with_entity(&clang, source, |e| {
+        let children = e.get_children();
+
+        #[cfg(feature="gte_clang_3_7")]
+        fn test_get_offset_of_field(fields: &[Entity]) {
+            assert_eq!(fields[0].get_offset_of_field(), Ok(0));
+            assert_eq!(fields[1].get_offset_of_field(), Ok(8));
+        }
+
+        #[cfg(not(feature="gte_clang_3_7"))]
+        fn test_get_offset_of_field(_: &[Entity]) {}
+
+        test_get_offset_of_field(&children[0].get_children());
+    });
+
+    let source = "
+        const int x = 0;
+    ";
+
+    with_entity(&clang, source, |e| {
+        let children = e.get_children();
+
+        #[cfg(feature="gte_clang_7_0")]
+        fn test_is_invalid_declaration(entity: Entity) {
+            assert_eq!(entity.is_invalid_declaration(), false);
+        }
+
+        #[cfg(not(feature="gte_clang_7_0"))]
+        fn test_is_invalid_declaration(_: Entity) {}
+
+        test_is_invalid_declaration(children[0]);
+    });
+
+    let source = "
+        @interface Foo
+        - @property NSString *x;
+        @end
+    ";
+
+    with_translation_unit(&clang, "test.mm", source, &[], |_, _, tu| {
+        let children = tu.get_entity().get_children();
+
+        #[cfg(feature="gte_clang_8_0")]
+        fn test_get_objc_getter_setter_name(properties: &[Entity]) {
+            assert_eq!(properties[0].get_objc_getter_name().as_ref().map(|s| s.as_ref()), Some("x"));
+            assert_eq!(properties[0].get_objc_setter_name().as_ref().map(|s| s.as_ref()), Some("setX:"));
+        }
+
+        #[cfg(not(feature="gte_clang_8_0"))]
+        fn test_get_objc_getter_setter_name(_: &[Entity]) {}
+
+        test_get_objc_getter_setter_name(&children[1].get_children());
+    });
+
     // Index _____________________________________
 
     let mut index = Index::new(&clang, false, false);
@@ -1143,6 +1204,52 @@ fn test() {
     with_types(&clang, source, |ts| {
         assert!(!ts[0].is_variadic());
         assert!(ts[1].is_variadic());
+    });
+
+    let source = "
+        void f(int * _Nullable x, int * _Nonnull y);
+    ";
+
+    with_types(&clang, source, |ts| {
+        #[cfg(feature="gte_clang_8_0")]
+        fn test_get_nullability(ts: &[Type]) {
+            assert_eq!(ts[0].get_nullability(), Some(Nullability::Nullable));
+            assert_eq!(ts[1].get_nullability(), Some(Nullability::NonNull));
+        }
+
+        #[cfg(not(feature="gte_clang_8_0"))]
+        fn test_get_nullability(_: &[Type]) {}
+
+        test_get_nullability(&ts[0].get_argument_types().unwrap());
+    });
+
+    let source = "
+        @class C<T>;
+        @protocol P
+        @end
+        C<C*><P> *x;
+        C* y;
+    ";
+
+    with_translation_unit(&clang, "test.mm", source, &[], |_, _, tu| {
+        let children = tu.get_entity().get_children();
+
+        #[cfg(feature="gte_clang_8_0")]
+        fn test_objc_object_type(e: &[Entity]) {
+            let ty = e[3].get_type().unwrap().get_pointee_type().unwrap();
+            assert_eq!(ty.get_objc_object_base_type(), Some(e[1].get_type().unwrap()));
+            let protocols = ty.get_objc_protocol_declarations();
+            assert_eq!(protocols.len(), 1);
+            assert_eq!(protocols[0], e[2]);
+            let args = ty.get_objc_type_arguments();
+            assert_eq!(args.len(), 1);
+            assert_eq!(args[0], e[4].get_type().unwrap());
+        }
+
+        #[cfg(not(feature="gte_clang_8_0"))]
+        fn test_objc_object_type(_: &[Entity]) {}
+
+        test_objc_object_type(&children);
     });
 
     // Usr _______________________________________

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -86,10 +86,7 @@ fn with_translation_unit<'c, F>(
 ) where F: FnOnce(&Path, &Path, TranslationUnit) {
     with_temporary_file(name, contents, |d, file| {
         let index = Index::new(clang, false, false);
-        #[cfg(feature="gte_clang_8_0")]
-        f(d, &file, index.parser(file).include_attributed_types(true).arguments(arguments).parse().unwrap());
-        // #[cfg(not(feature="gte_clang_8_0"))]
-        // f(d, &file, index.parser(file).arguments(arguments).parse().unwrap());
+        f(d, &file, index.parser(file).arguments(arguments).parse().unwrap());
     });
 }
 


### PR DESCRIPTION
Just an update to the latest clang-sys along with the new features added in libclang v7.0 and v8.0. Also added a missing function from an older version. Fix-it listings are missing from v8.0, not sure of the best way to add them. 