### PR TITLE
Compilation database support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.22.1"
+version = "0.23.0"
 
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2197,7 +2197,7 @@ impl<'tu> Entity<'tu> {
         ) -> CXChildVisitResult {
             unsafe {
                 let &mut (tu, ref mut callback) =
-                    &mut *(data as *mut (&TranslationUnit, Box<EntityCallback>));
+                    &mut *(data as *mut (&TranslationUnit, Box<dyn EntityCallback>));
 
                 let entity = Entity::from_raw(cursor, tu);
                 let parent = Entity::from_raw(parent, tu);
@@ -2205,7 +2205,7 @@ impl<'tu> Entity<'tu> {
             }
         }
 
-        let mut data = (self.tu, Box::new(f) as Box<EntityCallback>);
+        let mut data = (self.tu, Box::new(f) as Box<dyn EntityCallback>);
         unsafe { clang_visitChildren(self.raw, visit, utility::addressof(&mut data)) != 0 }
     }
 
@@ -3110,7 +3110,7 @@ impl<'tu> Type<'tu> {
         extern fn visit(cursor: CXCursor, data: CXClientData) -> CXVisitorResult {
             unsafe {
                 let &mut (tu, ref mut callback) =
-                    &mut *(data as *mut (&TranslationUnit, Box<Callback>));
+                    &mut *(data as *mut (&TranslationUnit, Box<dyn Callback>));
 
                 if callback.call(Entity::from_raw(cursor, tu)) {
                     CXVisit_Continue
@@ -3120,7 +3120,7 @@ impl<'tu> Type<'tu> {
             }
         }
 
-        let mut data = (self.tu, Box::new(f) as Box<Callback>);
+        let mut data = (self.tu, Box::new(f) as Box<dyn Callback>);
         unsafe {
             let data = utility::addressof(&mut data);
             Some(clang_Type_visitFields(self.raw, visit, data) == CXVisit_Break)

--- a/src/source.rs
+++ b/src/source.rs
@@ -480,8 +480,8 @@ fn visit<'tu, F, G>(tu: &'tu TranslationUnit<'tu>, f: F, g: G) -> bool
     extern fn visit(data: CXClientData, cursor: CXCursor, range: CXSourceRange) -> CXVisitorResult {
         unsafe {
             let &mut (tu, ref mut callback):
-                &mut (&TranslationUnit, Box<Callback>) =
-                    &mut *(data as *mut (&TranslationUnit, Box<Callback>));
+                &mut (&TranslationUnit, Box<dyn Callback>) =
+                    &mut *(data as *mut (&TranslationUnit, Box<dyn Callback>));
 
             if callback.call(Entity::from_raw(cursor, tu), SourceRange::from_raw(range, tu)) {
                 CXVisit_Continue
@@ -491,7 +491,7 @@ fn visit<'tu, F, G>(tu: &'tu TranslationUnit<'tu>, f: F, g: G) -> bool
         }
     }
 
-    let mut data = (tu, Box::new(f) as Box<Callback>);
+    let mut data = (tu, Box::new(f) as Box<dyn Callback>);
     let visitor = CXCursorAndRangeVisitor { context: utility::addressof(&mut data), visit };
     g(visitor) == CXResult_VisitBreak
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::ffi::{CStr, CString};
-use std::path::{Path};
+use std::path::{Path, PathBuf};
 
 use clang_sys::*;
 
@@ -254,6 +254,11 @@ pub fn addressof<T>(value: &mut T) -> *mut c_void {
 
 pub fn from_path<P: AsRef<Path>>(path: P) -> CString {
     from_string(path.as_ref().as_os_str().to_str().expect("invalid C string"))
+}
+
+pub fn to_path(clang: CXString) -> PathBuf {
+    let rust_string = to_string(clang);
+    PathBuf::from(rust_string)
 }
 
 pub fn from_string<S: AsRef<str>>(string: S) -> CString {


### PR DESCRIPTION
Clang provides APIs for working with a compilation database (a `compile_commands.json` file that maps each compiled source file to the command and args used to build it). Most of the needed functions are already in clang-sys, but clang-rs provided no high-level binds.

This adds some fairly direct bindings to the C API: from a directory, you get a `CompilationDatabase` struct. From there you can get a `CompileCommands` struct that represents all commands, or ones for a provided path. From that, you finally get a `Vec<CompileCommand>`, each of which provides its working directory, filename, args, etc.

This seems a little clunky - it would be nice for the `CompilationDatabase` calls to return a `Vec<CompileCommand>` directly, but the C API implies that the data for each individual `CompileCommand` is tied to the `CompileCommands` it came from.