### PR TITLE
Prefer mem::MaybeUninit over mem::uninitialized()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "clang"
 authors = ["Kyle Mayes <kyle@mayeses.com>"]
 
-version = "0.23.0"
+version = "0.23.1"
 
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -313,11 +313,11 @@ impl CompletionResults {
     /// Returns the categorization of the entity that contains the code completion context for this
     /// set of code completion results and whether that entity is incomplete, if applicable.
     pub fn get_container_kind(&self) -> Option<(EntityKind, bool)> {
+        let mut incomplete = mem::MaybeUninit::uninit();
         unsafe {
-            let mut incomplete = mem::uninitialized();
-            match clang_codeCompleteGetContainerKind(self.ptr, &mut incomplete) {
+            match clang_codeCompleteGetContainerKind(self.ptr, incomplete.as_mut_ptr()) {
                 CXCursor_InvalidCode => None,
-                other => Some((mem::transmute(other), incomplete != 0)),
+                other => Some((mem::transmute(other), incomplete.assume_init() != 0)),
             }
         }
     }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -109,12 +109,12 @@ impl<'tu> Diagnostic<'tu> {
 
     /// Returns the fix-its for this diagnostic.
     pub fn get_fix_its(&self) -> Vec<FixIt<'tu>> {
+        let mut range = mem::MaybeUninit::uninit();
         unsafe {
             (0..clang_getDiagnosticNumFixIts(self.ptr)).map(|i| {
-                let mut range = mem::uninitialized();
-                let fixit = clang_getDiagnosticFixIt(self.ptr, i, &mut range);
+                let fixit = clang_getDiagnosticFixIt(self.ptr, i, range.as_mut_ptr());
                 let string = utility::to_string(fixit);
-                let range = SourceRange::from_raw(range, self.tu);
+                let range = SourceRange::from_raw(range.assume_init(), self.tu);
                 if string.is_empty() {
                     FixIt::Deletion(range)
                 } else if range.get_start() == range.get_end() {


### PR DESCRIPTION
The latter was deprecated in 1.38.