### PR TITLE
Fix AppVeyor build

### DIFF
--- a/ci/install.bat
+++ b/ci/install.bat
@@ -1,3 +1,5 @@
+@echo on
+
 curl -sSf https://static.rust-lang.org/dist/rust-1.37.0-i686-pc-windows-msvc.exe -o rust.exe
 rust.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
 set PATH=%PATH%;C:\Rust\bin

--- a/ci/install.bat
+++ b/ci/install.bat
@@ -1,10 +1,8 @@
-@echo on
-
-curl -sSf https://static.rust-lang.org/dist/rust-1.37.0-i686-pc-windows-msvc.exe -o rust.exe
+curl -sSLf https://static.rust-lang.org/dist/rust-1.37.0-i686-pc-windows-msvc.exe -o rust.exe
 rust.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
 set PATH=%PATH%;C:\Rust\bin
 
-curl -sSf http://releases.llvm.org/%LLVM_VERSION%/LLVM-%LLVM_VERSION%-win32.exe -o LLVM.exe
+curl -sSLf https://releases.llvm.org/%LLVM_VERSION%/LLVM-%LLVM_VERSION%-win32.exe -o LLVM.exe
 7z x LLVM.exe -oC:\LLVM
 set PATH=%PATH%;C:\LLVM\bin
 set LIBCLANG_PATH=C:\LLVM\bin


### PR DESCRIPTION
curl unhelpfully doesn't follow redirects by default. LLVM was redirecting to https://, so I updated the link to that and added `-L` to follow future redirects.