### PR TITLE
upgrade action versions to silent nodejs 12 deprecated warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
         rust: ["1.40.0"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # LLVM and Clang
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
           key: ${{ matrix.os }}-llvm-${{ matrix.clang[0] }}


### PR DESCRIPTION
CI complains about some deprecations
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/cache, actions-rs/toolchain, actions-rs/cargo, actions-rs/cargo, actions/cache, actions/checkout

The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Four actions has outdated nodejs, `actions/checkout`, `actions/cache`, `actions-rs/toolchain` and `actions-rs/toolchain`

`set-output` and `save-state` warnings are originated from `actions-rs/toolchain`

I upgrade `actions/checkout` and `actions/cache` in this PR, but unfortunately, all `actions-rs` related repos seem to be abandoned, and they have warning related PR open in their repos, but seems nobody cares

https://github.com/actions-rs/cargo/issues/216

https://github.com/actions-rs/toolchain/issues/219