### PR TITLE
Mark to_string function as unsafe

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -424,7 +424,7 @@ impl<'r> CompletionString<'r> {
             macro_rules! text {
                 ($variant:ident) => ({
                     let text = unsafe { clang_getCompletionChunkText(self.ptr, i as c_uint) };
-                    CompletionChunk::$variant(utility::to_string(text))
+                    CompletionChunk::$variant(unsafe { utility::to_string(text) })
                 });
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2885,7 +2885,7 @@ impl PlatformAvailability {
 
     fn from_raw(raw: CXPlatformAvailability) -> PlatformAvailability {
         PlatformAvailability {
-            platform: utility::to_string(raw.Platform),
+            platform: unsafe { utility::to_string(raw.Platform) },
             unavailable: raw.Unavailable != 0,
             introduced: raw.Introduced.map(Version::from_raw),
             deprecated: raw.Deprecated.map(Version::from_raw),
@@ -3140,7 +3140,7 @@ impl<'i> fmt::Debug for TranslationUnit<'i> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let spelling = unsafe { clang_getTranslationUnitSpelling(self.ptr) };
         formatter.debug_struct("TranslationUnit")
-            .field("spelling", &utility::to_string(spelling))
+            .field("spelling", unsafe { &utility::to_string(spelling) })
             .finish()
     }
 }
@@ -3540,7 +3540,7 @@ impl Usr {
         let class = utility::from_string(class);
         let category = utility::from_string(category);
         let raw = unsafe { clang_constructUSR_ObjCCategory(class.as_ptr(), category.as_ptr()) };
-        Usr(utility::to_string(raw))
+        Usr(unsafe { utility::to_string(raw) })
     }
 
     /// Constructs a new `Usr` from an Objective-C class.
@@ -3563,7 +3563,7 @@ impl Usr {
             let name = utility::from_string(name);
             let instance = instance as c_uint;
             let raw = unsafe { clang_constructUSR_ObjCMethod(name.as_ptr(), instance, s) };
-            Usr(utility::to_string(raw))
+            Usr(unsafe { utility::to_string(raw) })
         })
     }
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -265,8 +265,8 @@ pub fn from_string<S: AsRef<str>>(string: S) -> CString {
     CString::new(string.as_ref()).expect("invalid C string")
 }
 
-pub fn to_string(clang: CXString) -> String {
-    unsafe {
+pub unsafe fn to_string(clang: CXString) -> String {
+     {
         let c = CStr::from_ptr(clang_getCString(clang));
         let rust = c.to_str().expect("invalid Rust string").into();
         clang_disposeString(clang);

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -257,7 +257,7 @@ pub fn from_path<P: AsRef<Path>>(path: P) -> CString {
 }
 
 pub fn to_path(clang: CXString) -> PathBuf {
-    let rust_string = to_string(clang);
+    let rust_string = unsafe { to_string(clang) };
     PathBuf::from(rust_string)
 }
 
@@ -266,12 +266,10 @@ pub fn from_string<S: AsRef<str>>(string: S) -> CString {
 }
 
 pub unsafe fn to_string(clang: CXString) -> String {
-     {
         let c = CStr::from_ptr(clang_getCString(clang));
         let rust = c.to_str().expect("invalid Rust string").into();
         clang_disposeString(clang);
         rust
-    }
 }
 
 pub fn to_string_option(clang: CXString) -> Option<String> {


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/KyleMayes/clang-rs/blob/c25b348c5bddffb66e5dd1fdce62e1bb462bd73c/src/utility.rs#L268-L275
[https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_ptr](url)
The unsafe function called needs to ensure that the parameter must be:

- The memory pointed to by ptr must contain a valid nul terminator at the end of the string.
- ptr must be valid for reads of bytes up to and including the null terminator. 
- The memory referenced by the returned CStr must not be mutated for the duration of lifetime 'a.

and it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the to_string function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.