### PR TITLE
fix: added unsafe blocks for unsafe to_string function

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -385,7 +385,7 @@ impl<'r> CompletionString<'r> {
         iter!(
             clang_getCompletionNumAnnotations(self.ptr),
             clang_getCompletionAnnotation(self.ptr),
-        ).map(utility::to_string).collect()
+        ).map(|s| unsafe { utility::to_string(s) } ).collect()
     }
 
     /// Returns the availability of this completion string.

--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -149,7 +149,7 @@ impl BlockCommand {
         let arguments = iter!(
             clang_BlockCommandComment_getNumArgs(raw),
             clang_BlockCommandComment_getArgText(raw),
-        ).map(utility::to_string).collect();
+        ).map(|s| unsafe { utility::to_string(s) } ).collect();
         let paragraph = clang_BlockCommandComment_getParagraph(raw);
         let children = Comment::from_raw(paragraph).get_children();
         BlockCommand { command, arguments, children }
@@ -249,7 +249,7 @@ impl InlineCommand {
         let arguments = iter!(
             clang_InlineCommandComment_getNumArgs(raw),
             clang_InlineCommandComment_getArgText(raw),
-        ).map(utility::to_string).collect();
+        ).map(|s| unsafe { utility::to_string(s) } ).collect();
         let style = match clang_InlineCommandComment_getRenderKind(raw) {
             CXCommentInlineCommandRenderKind_Normal => None,
             other => Some(mem::transmute(other)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1787,7 +1787,7 @@ impl<'cmds> CompileCommand<'cmds> {
             clang_CompileCommand_getNumArgs(self.ptr),
             clang_CompileCommand_getArg(self.ptr),
         )
-        .map(utility::to_string)
+        .map(|s| unsafe { utility::to_string(s) } )
         .collect()
     }
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -273,7 +273,7 @@ pub unsafe fn to_string(clang: CXString) -> String {
 }
 
 pub fn to_string_option(clang: CXString) -> Option<String> {
-    clang.map(to_string).and_then(|s| {
+    clang.map(|s| unsafe { to_string(s) } ).and_then(|s| {
         if !s.is_empty() {
             Some(s)
         } else {


### PR DESCRIPTION
Issue #53 marked to_string as unsafe. 
There were various locations where this function was used that had not yet been updated to include an unsafe block, resulting in the project not being able to be built.
This PR simply adds those few unsafe blocks.