### PR TITLE
Lossily convert strings

### DIFF
--- a/src/utility.rs
+++ b/src/utility.rs
@@ -267,7 +267,7 @@ pub fn from_string<S: AsRef<str>>(string: S) -> CString {
 
 pub unsafe fn to_string(clang: CXString) -> String {
         let c = CStr::from_ptr(clang_getCString(clang));
-        let rust = c.to_str().expect("invalid Rust string").into();
+        let rust = c.to_string_lossy().into();
         clang_disposeString(clang);
         rust
 }


### PR DESCRIPTION
This is not really the correct solution, but at least it avoids a panic when fetching documentation that isn't UTF-8. A better solution would be to return `CString` to the user, but that's a breaking change, and thus harder to release in a minor version.