### PR TITLE
Fix build errors for recent Rust compilers

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -385,7 +385,7 @@ impl<'r> CompletionString<'r> {
         iter!(
             clang_getCompletionNumAnnotations(self.ptr),
             clang_getCompletionAnnotation(self.ptr),
-        ).map(utility::to_string).collect()
+        ).map(|s| unsafe { utility::to_string(s) }).collect()
     }
 
     /// Returns the availability of this completion string.

--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -149,7 +149,7 @@ impl BlockCommand {
         let arguments = iter!(
             clang_BlockCommandComment_getNumArgs(raw),
             clang_BlockCommandComment_getArgText(raw),
-        ).map(utility::to_string).collect();
+        ).map(|s| unsafe { utility::to_string(s) }).collect();
         let paragraph = clang_BlockCommandComment_getParagraph(raw);
         let children = Comment::from_raw(paragraph).get_children();
         BlockCommand { command, arguments, children }
@@ -249,7 +249,7 @@ impl InlineCommand {
         let arguments = iter!(
             clang_InlineCommandComment_getNumArgs(raw),
             clang_InlineCommandComment_getArgText(raw),
-        ).map(utility::to_string).collect();
+        ).map(|s| unsafe { utility::to_string(s) }).collect();
         let style = match clang_InlineCommandComment_getRenderKind(raw) {
             CXCommentInlineCommandRenderKind_Normal => None,
             other => Some(mem::transmute(other)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1092,7 +1092,7 @@ pub enum PrintingPolicyFlag {
 // RefQualifier __________________________________
 
 /// Indicates the ref qualifier of a C++ function or method type.
-#[cfg_attr(feature="cargo-clippy", allow(clippy::enum_variant_names))]
+#[allow(clippy::enum_variant_names)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub enum RefQualifier {
@@ -1787,7 +1787,7 @@ impl<'cmds> CompileCommand<'cmds> {
             clang_CompileCommand_getNumArgs(self.ptr),
             clang_CompileCommand_getArg(self.ptr),
         )
-        .map(utility::to_string)
+        .map(|s| unsafe { utility::to_string(s) })
         .collect()
     }
 
@@ -2518,7 +2518,7 @@ impl<'tu> Entity<'tu> {
             }
         }
 
-        extern fn visit(
+        extern "C" fn visit(
             cursor: CXCursor, parent: CXCursor, data: CXClientData
         ) -> CXChildVisitResult {
             unsafe {

--- a/src/source.rs
+++ b/src/source.rs
@@ -502,7 +502,7 @@ fn visit<'tu, F, G>(tu: &'tu TranslationUnit<'tu>, f: F, g: G) -> bool
         }
     }
 
-    extern fn visit(data: CXClientData, cursor: CXCursor, range: CXSourceRange) -> CXVisitorResult {
+    extern "C" fn visit(data: CXClientData, cursor: CXCursor, range: CXSourceRange) -> CXVisitorResult {
         unsafe {
             let &mut (tu, ref mut callback):
                 &mut (&TranslationUnit, Box<dyn Callback>) =

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -273,7 +273,7 @@ pub unsafe fn to_string(clang: CXString) -> String {
 }
 
 pub fn to_string_option(clang: CXString) -> Option<String> {
-    clang.map(to_string).and_then(|s| {
+    clang.map(|s| unsafe { to_string(s) }).and_then(|s| {
         if !s.is_empty() {
             Some(s)
         } else {


### PR DESCRIPTION
- this was needed to compile clang with rustc 1.92.0-nightly (839222065 2025-10-05)
- warnings still exist
- Wrap unsafe to_string calls in closures with explicit unsafe blocks
- Add explicit "C" ABI to extern function declarations
- Remove deprecated cargo-clippy feature guard